### PR TITLE
fix: remove shared mutable HashSet from incremental generator (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- Remove shared mutable HashSet from incremental generator to fix disappearing generated VersionInformation class on incremental builds
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
+++ b/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
@@ -332,4 +332,62 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
 
         Assert.Empty(result.Diagnostics);
     }
+
+    [Fact]
+    public void GeneratorStillProducesSourceAfterIncrementalRebuild()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        const string SOURCE_1 = """
+            namespace TestAssembly;
+            public class C1 { }
+            """;
+
+        const string SOURCE_2 = """
+            namespace TestAssembly;
+            public class C2 { }
+            """;
+
+        CSharpCompilation compilation1 = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(text: SOURCE_1, cancellationToken: cancellationToken)],
+            references: GetReferences(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new VersionInformationCodeGenerator().AsSourceGenerator()],
+            additionalTexts: null,
+            parseOptions: null,
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(null)
+        );
+
+        driver = driver.RunGenerators(compilation: compilation1, cancellationToken: cancellationToken);
+        GeneratorDriverRunResult result1 = driver.GetRunResult();
+
+        int sources1 = 0;
+
+        foreach (GeneratorRunResult r in result1.Results)
+        {
+            sources1 += r.GeneratedSources.Length;
+        }
+
+        Assert.Equal(1, sources1);
+
+        CSharpCompilation compilation2 = compilation1.AddSyntaxTrees(
+            CSharpSyntaxTree.ParseText(text: SOURCE_2, cancellationToken: cancellationToken)
+        );
+
+        driver = driver.RunGenerators(compilation: compilation2, cancellationToken: cancellationToken);
+        GeneratorDriverRunResult result2 = driver.GetRunResult();
+
+        int sources2 = 0;
+
+        foreach (GeneratorRunResult r in result2.Results)
+        {
+            sources2 += r.GeneratedSources.Length;
+        }
+
+        Assert.Equal(1, sources2);
+    }
 }

--- a/src/Credfeto.Version.Information.Generator/Credfeto.Version.Information.Generator.csproj
+++ b/src/Credfeto.Version.Information.Generator/Credfeto.Version.Information.Generator.csproj
@@ -57,11 +57,6 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)SourceGenerator.props" Condition="Exists('$(SolutionDir)SourceGenerator.props')" />
   <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>Credfeto.Version.Information.Generator.Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-  <ItemGroup>
     <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />
     <!-- error NU1902: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known moderate severity vulnerability -->

--- a/src/Credfeto.Version.Information.Generator/Models/NamespaceError.cs
+++ b/src/Credfeto.Version.Information.Generator/Models/NamespaceError.cs
@@ -5,7 +5,7 @@ namespace Credfeto.Version.Information.Generator.Models;
 
 [DebuggerDisplay("{NamespaceInfo} {ErrorInfo}")]
 [StructLayout(LayoutKind.Auto)]
-internal readonly record struct NamespaceError
+public readonly record struct NamespaceError
 {
     public NamespaceError()
         : this(namespaceInfo: null, errorInfo: null) { }

--- a/src/Credfeto.Version.Information.Generator/Models/NamespaceGeneration.cs
+++ b/src/Credfeto.Version.Information.Generator/Models/NamespaceGeneration.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
@@ -18,4 +20,42 @@ public readonly record struct NamespaceGeneration
     public AssemblyIdentity Assembly { get; }
 
     public ImmutableDictionary<string, string> Attributes { get; }
+
+    public bool Equals(NamespaceGeneration other)
+    {
+        if (!this.Assembly.Equals(other.Assembly))
+        {
+            return false;
+        }
+
+        if (this.Attributes.Count != other.Attributes.Count)
+        {
+            return false;
+        }
+
+        foreach (KeyValuePair<string, string> kvp in this.Attributes)
+        {
+            if (
+                !other.Attributes.TryGetValue(kvp.Key, out string? value)
+                || !string.Equals(value, kvp.Value, StringComparison.Ordinal)
+            )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override int GetHashCode()
+    {
+        int h = this.Assembly.GetHashCode();
+
+        foreach (KeyValuePair<string, string> kvp in this.Attributes)
+        {
+            h ^= StringComparer.Ordinal.GetHashCode(kvp.Key) ^ StringComparer.Ordinal.GetHashCode(kvp.Value);
+        }
+
+        return h;
+    }
 }

--- a/src/Credfeto.Version.Information.Generator/VersionInformationCodeGenerator.cs
+++ b/src/Credfeto.Version.Information.Generator/VersionInformationCodeGenerator.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -18,62 +17,36 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
 {
     private const string CLASS_NAME = "VersionInformation";
 
-    private static readonly NamespaceError IgnoreResult = new();
-
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        context.RegisterSourceOutput(ExtractNamespaces(context), action: GenerateVersionInformation);
-    }
-
-    private static IncrementalValuesProvider<(
-        NamespaceError Left,
-        AnalyzerConfigOptionsProvider Right
-    )> ExtractNamespaces(in IncrementalGeneratorInitializationContext context)
-    {
-        HashSet<string> assembliesToGenerateVersionInformation = new(StringComparer.Ordinal);
-
-        return context
+        IncrementalValueProvider<bool> hasNamespaces = context
             .SyntaxProvider.CreateSyntaxProvider(
                 predicate: static (syntaxNode, _) =>
                     syntaxNode is NamespaceDeclarationSyntax or FileScopedNamespaceDeclarationSyntax,
-                transform: (generatorSyntaxContext, cancellationToken) =>
-                    GetNamespace(
-                        generatorSyntaxContext: generatorSyntaxContext,
-                        generated: assembliesToGenerateVersionInformation,
-                        cancellationToken: cancellationToken
-                    )
+                transform: static (_, _) => true
             )
+            .Collect()
+            .Select(static (items, _) => !items.IsEmpty);
+
+        IncrementalValueProvider<NamespaceError> assemblyInfo = context.CompilationProvider.Select(
+            static (compilation, cancellationToken) => ExtractAssemblyInfo(compilation, cancellationToken)
+        );
+
+        IncrementalValueProvider<(NamespaceError Left, AnalyzerConfigOptionsProvider Right)> combined = assemblyInfo
+            .Combine(hasNamespaces)
+            .Select(static (pair, _) => pair.Right ? pair.Left : new NamespaceError())
             .Combine(context.AnalyzerConfigOptionsProvider);
+
+        context.RegisterSourceOutput(combined, action: GenerateVersionInformation);
     }
 
-    private static NamespaceError GetNamespace(
-        in GeneratorSyntaxContext generatorSyntaxContext,
-        HashSet<string> generated,
-        CancellationToken cancellationToken
-    )
+    private static NamespaceError ExtractAssemblyInfo(Compilation compilation, CancellationToken cancellationToken)
     {
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (
-                generatorSyntaxContext.Node
-                is not NamespaceDeclarationSyntax
-                    and not FileScopedNamespaceDeclarationSyntax
-            )
-            {
-                return IgnoreResult;
-            }
-
-            Compilation compilation = generatorSyntaxContext.SemanticModel.Compilation;
-
-            AssemblyIdentity assembly = GetAssembly(compilation);
-
-            if (!generated.Add(assembly.Name))
-            {
-                return IgnoreResult;
-            }
-
+            AssemblyIdentity assembly = compilation.Assembly.Identity;
             cancellationToken.ThrowIfCancellationRequested();
 
             ImmutableDictionary<string, string> attributes = ExtractAttributes(compilation.Assembly);
@@ -83,16 +56,8 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            return UnhandledException(generatorSyntaxContext: generatorSyntaxContext, exception: exception);
+            return new(new ErrorInfo(Location.None, exception: exception));
         }
-    }
-
-    private static NamespaceError UnhandledException(
-        in GeneratorSyntaxContext generatorSyntaxContext,
-        Exception exception
-    )
-    {
-        return new(new ErrorInfo(generatorSyntaxContext.Node.GetLocation(), exception: exception));
     }
 
     private static ImmutableDictionary<string, string> ExtractAttributes(in IAssemblySymbol assemblySymbol)
@@ -124,11 +89,6 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
         object? v = a.ConstructorArguments[0].Value;
 
         return (key: a.AttributeClass.Name, value: v?.ToString() ?? string.Empty);
-    }
-
-    private static AssemblyIdentity GetAssembly(Compilation compilation)
-    {
-        return compilation.Assembly.Identity;
     }
 
     private static void ReportException(Location location, in SourceProductionContext context, Exception exception)


### PR DESCRIPTION
## Summary

- Removes the shared mutable `HashSet<string> assembliesToGenerateVersionInformation` closure from the `CreateSyntaxProvider` transform in `VersionInformationCodeGenerator.ExtractNamespaces`
- Replaces the syntax-provider-driven pipeline with a `CompilationProvider`-based pipeline (one pure output per compilation, no shared state)
- Preserves the existing `NoNamespaceSourceProducesNoGeneratedFiles` behaviour by combining with a syntax-provider-derived `bool hasNamespaces`
- Adds an incremental-build regression test that runs the driver twice and asserts the generated source is still produced on the second run

## Test plan

- [ ] Existing tests (`DuplicateNamespacesProduceOnlyOneGeneratedFile`, `NoNamespaceSourceProducesNoGeneratedFiles`, etc.) still pass
- [ ] New test `GeneratorStillProducesSourceAfterIncrementalRebuild` passes — verifies the incremental path that the current code breaks
- [ ] Build and test suite pass cleanly

Closes #111