### PR TITLE
fix: reduce generator pipeline work and fix model equality for incremental caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 - Remove shared mutable HashSet from incremental generator to fix disappearing generated VersionInformation class on incremental builds
+- Reduce incremental generator pipeline work and fix model equality so the generator caches correctly across incremental builds
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Version.Information.Generator.Tests/Models/ErrorInfoTests.cs
+++ b/src/Credfeto.Version.Information.Generator.Tests/Models/ErrorInfoTests.cs
@@ -13,15 +13,15 @@ public sealed class ErrorInfoTests : TestBase
     {
         Exception exception = new InvalidOperationException("test error");
         ErrorInfo errorInfo = new(location: Location.None, exception: exception);
-        Assert.Equal(Location.None, errorInfo.Location);
+        Assert.Equal(Location.None.ToString(), errorInfo.LocationString);
     }
 
     [Fact]
-    public void ExceptionIsStoredCorrectly()
+    public void ExceptionMessageIsStoredCorrectly()
     {
         Exception exception = new InvalidOperationException("test error");
         ErrorInfo errorInfo = new(location: Location.None, exception: exception);
-        Assert.Same(exception, errorInfo.Exception);
+        Assert.Equal(exception.Message, errorInfo.ExceptionMessage);
     }
 
     [Fact]
@@ -30,7 +30,7 @@ public sealed class ErrorInfoTests : TestBase
         const string MESSAGE = "specific error message";
         Exception exception = new InvalidOperationException(MESSAGE);
         ErrorInfo errorInfo = new(location: Location.None, exception: exception);
-        Assert.Equal(MESSAGE, errorInfo.Exception.Message);
+        Assert.Equal(MESSAGE, errorInfo.ExceptionMessage);
     }
 
     [Fact]

--- a/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
+++ b/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
@@ -392,6 +392,24 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
         Assert.Equal(1, sources2);
     }
 
+    private static readonly string[] AllTrackingNames =
+    [
+        VersionInformationCodeGenerator.TRACKING_NAME_HAS_NAMESPACES,
+        VersionInformationCodeGenerator.TRACKING_NAME_ASSEMBLY_INFO,
+        VersionInformationCodeGenerator.TRACKING_NAME_ROOT_NAMESPACE,
+        VersionInformationCodeGenerator.TRACKING_NAME_COMBINED,
+    ];
+
+    private static CSharpCompilation CreateSingleFileCompilation(string source, in CancellationToken cancellationToken)
+    {
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(text: source, cancellationToken: cancellationToken)],
+            references: GetReferences(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+    }
+
     [Fact]
     public void PipelineStepsAreCachedOnSemanticallyIrrelevantRerun()
     {
@@ -409,13 +427,6 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
             public class C1 { }
             """;
 
-        CSharpCompilation compilation1 = CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(text: SOURCE_1, cancellationToken: cancellationToken)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-        );
-
         GeneratorDriver driver = CSharpGeneratorDriver.Create(
             generators: [new VersionInformationCodeGenerator().AsSourceGenerator()],
             additionalTexts: null,
@@ -427,32 +438,27 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
             )
         );
 
-        driver = driver.RunGenerators(compilation: compilation1, cancellationToken: cancellationToken);
-
-        CSharpCompilation compilation2 = CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees:
-            [
-                CSharpSyntaxTree.ParseText(text: SOURCE_1_WITH_EXTRA_WHITESPACE, cancellationToken: cancellationToken),
-            ],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        driver = driver.RunGenerators(
+            compilation: CreateSingleFileCompilation(source: SOURCE_1, cancellationToken: cancellationToken),
+            cancellationToken: cancellationToken
         );
 
-        driver = driver.RunGenerators(compilation: compilation2, cancellationToken: cancellationToken);
+        driver = driver.RunGenerators(
+            compilation: CreateSingleFileCompilation(
+                source: SOURCE_1_WITH_EXTRA_WHITESPACE,
+                cancellationToken: cancellationToken
+            ),
+            cancellationToken: cancellationToken
+        );
+
         GeneratorDriverRunResult result = driver.GetRunResult();
 
         Assert.NotEmpty(result.Results);
 
-        AssertStepsCachedOrUnchanged(
-            result.Results[0].TrackedSteps[VersionInformationCodeGenerator.TRACKING_NAME_ASSEMBLY_INFO]
-        );
-        AssertStepsCachedOrUnchanged(
-            result.Results[0].TrackedSteps[VersionInformationCodeGenerator.TRACKING_NAME_ROOT_NAMESPACE]
-        );
-        AssertStepsCachedOrUnchanged(
-            result.Results[0].TrackedSteps[VersionInformationCodeGenerator.TRACKING_NAME_COMBINED]
-        );
+        foreach (string trackingName in AllTrackingNames)
+        {
+            AssertStepsCachedOrUnchanged(result.Results[0].TrackedSteps[trackingName]);
+        }
     }
 
     private static void AssertStepsCachedOrUnchanged(in ImmutableArray<IncrementalGeneratorRunStep> steps)

--- a/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
+++ b/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
@@ -443,6 +443,11 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
             cancellationToken: cancellationToken
         );
 
+        // Supply a distinct-but-equal-content options provider instance on the rerun so the assertions below
+        // actually exercise the rootnamespace/ErrorInfo value-equality caching this test guards, rather than
+        // trivially passing because the driver reused the exact same provider reference from creation.
+        driver = driver.WithUpdatedAnalyzerConfigOptions(new TestAnalyzerConfigOptionsProvider(null));
+
         driver = driver.RunGenerators(
             compilation: CreateSingleFileCompilation(
                 source: SOURCE_1_WITH_EXTRA_WHITESPACE,

--- a/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
+++ b/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using Credfeto.Version.Information.Generator.Tests.TestSupport;
 using FunFair.Test.Common;
@@ -389,5 +390,84 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
         }
 
         Assert.Equal(1, sources2);
+    }
+
+    [Fact]
+    public void PipelineStepsAreCachedOnSemanticallyIrrelevantRerun()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        const string SOURCE_1 = """
+            namespace TestAssembly;
+            public class C1 { }
+            """;
+
+        const string SOURCE_1_WITH_EXTRA_WHITESPACE = """
+            namespace TestAssembly;
+
+
+            public class C1 { }
+            """;
+
+        CSharpCompilation compilation1 = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(text: SOURCE_1, cancellationToken: cancellationToken)],
+            references: GetReferences(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new VersionInformationCodeGenerator().AsSourceGenerator()],
+            additionalTexts: null,
+            parseOptions: null,
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(null),
+            driverOptions: new GeneratorDriverOptions(
+                disabledOutputs: IncrementalGeneratorOutputKind.None,
+                trackIncrementalGeneratorSteps: true
+            )
+        );
+
+        driver = driver.RunGenerators(compilation: compilation1, cancellationToken: cancellationToken);
+
+        CSharpCompilation compilation2 = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(text: SOURCE_1_WITH_EXTRA_WHITESPACE, cancellationToken: cancellationToken),
+            ],
+            references: GetReferences(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        driver = driver.RunGenerators(compilation: compilation2, cancellationToken: cancellationToken);
+        GeneratorDriverRunResult result = driver.GetRunResult();
+
+        Assert.NotEmpty(result.Results);
+
+        AssertStepsCachedOrUnchanged(
+            result.Results[0].TrackedSteps[VersionInformationCodeGenerator.TRACKING_NAME_ASSEMBLY_INFO]
+        );
+        AssertStepsCachedOrUnchanged(
+            result.Results[0].TrackedSteps[VersionInformationCodeGenerator.TRACKING_NAME_ROOT_NAMESPACE]
+        );
+        AssertStepsCachedOrUnchanged(
+            result.Results[0].TrackedSteps[VersionInformationCodeGenerator.TRACKING_NAME_COMBINED]
+        );
+    }
+
+    private static void AssertStepsCachedOrUnchanged(in ImmutableArray<IncrementalGeneratorRunStep> steps)
+    {
+        Assert.NotEmpty(steps);
+
+        foreach (IncrementalGeneratorRunStep step in steps)
+        {
+            foreach ((_, IncrementalStepRunReason reason) in step.Outputs)
+            {
+                Assert.True(
+                    reason is IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged,
+                    "Expected step output reason to be Cached or Unchanged"
+                );
+            }
+        }
     }
 }

--- a/src/Credfeto.Version.Information.Generator/Extensions/NamespaceGenerationExtensions.cs
+++ b/src/Credfeto.Version.Information.Generator/Extensions/NamespaceGenerationExtensions.cs
@@ -9,16 +9,12 @@ namespace Credfeto.Version.Information.Generator.Extensions;
 
 internal static class NamespaceGenerationExtensions
 {
-    private static string GetNamespace(
-        in this NamespaceGeneration namespaceGeneration,
-        in AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider
-    )
+    private static string GetNamespace(in this NamespaceGeneration namespaceGeneration, string? rootNamespace)
     {
-        return GetRootNameSpace(analyzerConfigOptionsProvider: analyzerConfigOptionsProvider)
-            ?? namespaceGeneration.Namespace;
+        return rootNamespace ?? namespaceGeneration.Namespace;
     }
 
-    private static string? GetRootNameSpace(AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
+    internal static string? GetRootNameSpace(AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider)
     {
         return
             analyzerConfigOptionsProvider.GlobalOptions.TryGetValue(key: "build_property.rootnamespace", out string? ns)
@@ -27,14 +23,9 @@ internal static class NamespaceGenerationExtensions
             : null;
     }
 
-    private static string GetAssemblyProduct(
-        in this NamespaceGeneration namespaceGeneration,
-        in AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider
-    )
+    private static string GetAssemblyProduct(in this NamespaceGeneration namespaceGeneration, string? rootNamespace)
     {
-        return GetRootNameSpace(analyzerConfigOptionsProvider: analyzerConfigOptionsProvider)
-            ?? GetAssemblyTitle(namespaceGeneration)
-            ?? namespaceGeneration.Namespace;
+        return rootNamespace ?? GetAssemblyTitle(namespaceGeneration) ?? namespaceGeneration.Namespace;
     }
 
     private static string? GetAssemblyTitle(in NamespaceGeneration namespaceGeneration)
@@ -59,14 +50,12 @@ internal static class NamespaceGenerationExtensions
 
     public static CodeBuilder BuildSource(
         in this NamespaceGeneration namespaceGeneration,
-        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider,
+        string? rootNamespace,
         out string ns
     )
     {
-        ns = namespaceGeneration.GetNamespace(analyzerConfigOptionsProvider: analyzerConfigOptionsProvider);
-        string product = namespaceGeneration.GetAssemblyProduct(
-            analyzerConfigOptionsProvider: analyzerConfigOptionsProvider
-        );
+        ns = namespaceGeneration.GetNamespace(rootNamespace: rootNamespace);
+        string product = namespaceGeneration.GetAssemblyProduct(rootNamespace: rootNamespace);
         string version = RemoveGitHashFromVersion(namespaceGeneration.GetAssemblyVersion());
 
         CodeBuilder source = new();

--- a/src/Credfeto.Version.Information.Generator/Models/ErrorInfo.cs
+++ b/src/Credfeto.Version.Information.Generator/Models/ErrorInfo.cs
@@ -4,16 +4,19 @@ using Microsoft.CodeAnalysis;
 
 namespace Credfeto.Version.Information.Generator.Models;
 
-[DebuggerDisplay("{Location} {Exception}")]
+[DebuggerDisplay("{LocationString} {ExceptionMessage}")]
 public readonly record struct ErrorInfo
 {
     public ErrorInfo(Location location, Exception exception)
     {
-        this.Location = location;
-        this.Exception = exception;
+        this.LocationString = location.ToString();
+        this.ExceptionMessage = exception.Message;
+        this.ExceptionStackTrace = exception.StackTrace;
     }
 
-    public Location Location { get; }
+    public string LocationString { get; }
 
-    public Exception Exception { get; }
+    public string ExceptionMessage { get; }
+
+    public string? ExceptionStackTrace { get; }
 }

--- a/src/Credfeto.Version.Information.Generator/VersionInformationCodeGenerator.cs
+++ b/src/Credfeto.Version.Information.Generator/VersionInformationCodeGenerator.cs
@@ -17,6 +17,11 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
 {
     private const string CLASS_NAME = "VersionInformation";
 
+    public const string TRACKING_NAME_HAS_NAMESPACES = "HasNamespaces";
+    public const string TRACKING_NAME_ASSEMBLY_INFO = "AssemblyInfo";
+    public const string TRACKING_NAME_ROOT_NAMESPACE = "RootNamespace";
+    public const string TRACKING_NAME_COMBINED = "Combined";
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         IncrementalValueProvider<bool> hasNamespaces = context
@@ -26,16 +31,26 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
                 transform: static (_, _) => true
             )
             .Collect()
-            .Select(static (items, _) => !items.IsEmpty);
+            .Select(static (items, _) => !items.IsEmpty)
+            .WithTrackingName(TRACKING_NAME_HAS_NAMESPACES);
 
-        IncrementalValueProvider<NamespaceError> assemblyInfo = context.CompilationProvider.Select(
-            static (compilation, cancellationToken) => ExtractAssemblyInfo(compilation, cancellationToken)
-        );
+        IncrementalValueProvider<NamespaceError> assemblyInfo = context
+            .CompilationProvider.Select(
+                static (compilation, cancellationToken) => ExtractAssemblyInfo(compilation, cancellationToken)
+            )
+            .WithTrackingName(TRACKING_NAME_ASSEMBLY_INFO);
 
-        IncrementalValueProvider<(NamespaceError Left, AnalyzerConfigOptionsProvider Right)> combined = assemblyInfo
+        IncrementalValueProvider<string?> rootNamespace = context
+            .AnalyzerConfigOptionsProvider.Select(
+                static (provider, _) => NamespaceGenerationExtensions.GetRootNameSpace(provider)
+            )
+            .WithTrackingName(TRACKING_NAME_ROOT_NAMESPACE);
+
+        IncrementalValueProvider<(NamespaceError Left, string? Right)> combined = assemblyInfo
             .Combine(hasNamespaces)
             .Select(static (pair, _) => pair.Right ? pair.Left : new NamespaceError())
-            .Combine(context.AnalyzerConfigOptionsProvider);
+            .Combine(rootNamespace)
+            .WithTrackingName(TRACKING_NAME_COMBINED);
 
         context.RegisterSourceOutput(combined, action: GenerateVersionInformation);
     }
@@ -91,19 +106,32 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
         return (key: a.AttributeClass.Name, value: v?.ToString() ?? string.Empty);
     }
 
-    private static void ReportException(Location location, in SourceProductionContext context, Exception exception)
+    private static void ReportException(
+        in SourceProductionContext context,
+        string exceptionMessage,
+        string? exceptionStackTrace
+    )
     {
         context.ReportDiagnostic(
-            diagnostic: Diagnostic.Create(CreateUnhandledExceptionDiagnostic(exception), location: location)
+            diagnostic: Diagnostic.Create(
+                CreateUnhandledExceptionDiagnostic(
+                    exceptionMessage: exceptionMessage,
+                    exceptionStackTrace: exceptionStackTrace
+                ),
+                location: Location.None
+            )
         );
     }
 
-    private static DiagnosticDescriptor CreateUnhandledExceptionDiagnostic(Exception exception)
+    private static DiagnosticDescriptor CreateUnhandledExceptionDiagnostic(
+        string exceptionMessage,
+        string? exceptionStackTrace
+    )
     {
         return new(
             id: "VER001",
             title: "Unhandled Exception",
-            exception.Message + ' ' + exception.StackTrace,
+            exceptionMessage + ' ' + exceptionStackTrace,
             category: RuntimeVersionInformation.ToolName,
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true
@@ -112,13 +140,17 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
 
     private static void GenerateVersionInformation(
         SourceProductionContext sourceProductionContext,
-        (NamespaceError Left, AnalyzerConfigOptionsProvider Right) item
+        (NamespaceError Left, string? Right) item
     )
     {
         if (item.Left.ErrorInfo is not null)
         {
             ErrorInfo ei = item.Left.ErrorInfo.Value;
-            ReportException(location: ei.Location, context: sourceProductionContext, exception: ei.Exception);
+            ReportException(
+                context: sourceProductionContext,
+                exceptionMessage: ei.ExceptionMessage,
+                exceptionStackTrace: ei.ExceptionStackTrace
+            );
 
             return;
         }
@@ -131,20 +163,17 @@ public sealed class VersionInformationCodeGenerator : IIncrementalGenerator
         GenerateVersionInformation(
             sourceProductionContext: sourceProductionContext,
             namespaceInfo: item.Left.NamespaceInfo.Value,
-            analyzerConfigOptionsProvider: item.Right
+            rootNamespace: item.Right
         );
     }
 
     private static void GenerateVersionInformation(
         in SourceProductionContext sourceProductionContext,
         in NamespaceGeneration namespaceInfo,
-        AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider
+        string? rootNamespace
     )
     {
-        CodeBuilder source = namespaceInfo.BuildSource(
-            analyzerConfigOptionsProvider: analyzerConfigOptionsProvider,
-            out string ns
-        );
+        CodeBuilder source = namespaceInfo.BuildSource(rootNamespace: rootNamespace, out string ns);
 
         sourceProductionContext.AddSource($"{ns}.{CLASS_NAME}.generated.cs", sourceText: source.Text);
     }


### PR DESCRIPTION
## Summary

Two compounding incremental-generator performance issues in `VersionInformationCodeGenerator`:

1. The syntax provider previously ran a per-node pipeline (one entry per namespace declaration) to produce a single per-assembly output. This part is **already fixed** by #116 (merged): generation is now driven from `CompilationProvider.Select(...)`, collapsed to a single boolean gate from the syntax provider.
2. Model equality defeats caching:
   - `NamespaceGeneration` equality — **already fixed** by #116 (custom content-based `Equals`/`GetHashCode` over `AssemblyIdentity` + attribute dictionary).
   - `ErrorInfo` still holds `Location` and `Exception` references, which don't have meaningful/stable equality across runs — **not yet fixed**.
   - `AnalyzerConfigOptionsProvider` is still combined wholesale rather than narrowed to just `build_property.rootnamespace` — **not yet fixed**.

## Remaining scope for this PR

- `Models/ErrorInfo.cs` — replace `Location`/`Exception` with plain equatable string fields (message/stack trace).
- `VersionInformationCodeGenerator.cs` — narrow `AnalyzerConfigOptionsProvider` to a single extracted `string?` (root namespace) before combining.
- Add an incremental-caching regression test using `GeneratorDriverOptions(trackIncrementalGeneratorSteps: true)` and `.WithTrackingName(...)` to assert cache hits (`Cached`/`Unchanged`) on a second run.
- Update `ErrorInfoTests` for the new `ErrorInfo` shape.

See the [Implementation Plan](https://github.com/credfeto/credfeto-version-constants-generator/issues/114#issuecomment-4909935909) posted on the issue for full details (note: that plan predates #116, so its references to the per-node syntax pipeline and `NamespaceGeneration`'s dictionary-based equality are already resolved).

This is a placeholder draft — implementation follows in subsequent commits.

Closes #114