### PR TITLE
fix(#113): escape attribute values emitted into generated source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Fixed
 - Remove shared mutable HashSet from incremental generator to fix disappearing generated VersionInformation class on incremental builds
 - Reduce incremental generator pipeline work and fix model equality so the generator caches correctly across incremental builds
+- Escape attribute values emitted into generated source to prevent invalid C# when values contain quotes, backslashes, or newlines
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
+++ b/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
@@ -212,6 +212,103 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
     }
 
     [Fact]
+    public void GeneratorEscapesDoubleQuoteInCompanyAttribute()
+    {
+        const string SOURCE = """
+            using System.Reflection;
+            [assembly: AssemblyCompany("Acme \"Corp\"")]
+            namespace TestAssembly;
+            public class TestClass { }
+            """;
+
+        GeneratorDriverRunResult result = RunGenerator(source: SOURCE, assemblyName: "TestAssembly");
+
+        Assert.NotEmpty(result.Results);
+        Assert.NotEmpty(result.Results[0].GeneratedSources);
+
+        SourceText generatedText = result.Results[0].GeneratedSources[0].SourceText;
+        string generated = generatedText.ToString();
+        string expectedLiteral = SymbolDisplay.FormatLiteral("Acme \"Corp\"", quote: true);
+        Assert.Contains($"Company = {expectedLiteral}", generated, StringComparison.Ordinal);
+
+        AssertGeneratedSourceCompilesWithoutErrors(originalSource: SOURCE, generatedSource: generatedText.ToString());
+    }
+
+    [Fact]
+    public void GeneratorEscapesBackslashInCopyrightAttribute()
+    {
+        const string SOURCE = """
+            using System.Reflection;
+            [assembly: AssemblyCopyright("Copyright \\Acme Corp")]
+            namespace TestAssembly;
+            public class TestClass { }
+            """;
+
+        GeneratorDriverRunResult result = RunGenerator(source: SOURCE, assemblyName: "TestAssembly");
+
+        Assert.NotEmpty(result.Results);
+        Assert.NotEmpty(result.Results[0].GeneratedSources);
+
+        SourceText generatedText = result.Results[0].GeneratedSources[0].SourceText;
+        string generated = generatedText.ToString();
+        string expectedLiteral = SymbolDisplay.FormatLiteral("Copyright \\Acme Corp", quote: true);
+        Assert.Contains($"Copyright = {expectedLiteral}", generated, StringComparison.Ordinal);
+
+        AssertGeneratedSourceCompilesWithoutErrors(originalSource: SOURCE, generatedSource: generatedText.ToString());
+    }
+
+    [Fact]
+    public void GeneratorEscapesNewlineInInformationalVersionAttribute()
+    {
+        const string SOURCE = """
+            using System.Reflection;
+            [assembly: AssemblyInformationalVersion("1.0.0\nWithNewline")]
+            namespace TestAssembly;
+            public class TestClass { }
+            """;
+
+        GeneratorDriverRunResult result = RunGenerator(source: SOURCE, assemblyName: "TestAssembly");
+
+        Assert.NotEmpty(result.Results);
+        Assert.NotEmpty(result.Results[0].GeneratedSources);
+
+        SourceText generatedText = result.Results[0].GeneratedSources[0].SourceText;
+        string generated = generatedText.ToString();
+        string expectedLiteral = SymbolDisplay.FormatLiteral("1.0.0\nWithNewline", quote: true);
+        Assert.Contains($"Version = {expectedLiteral}", generated, StringComparison.Ordinal);
+
+        AssertGeneratedSourceCompilesWithoutErrors(originalSource: SOURCE, generatedSource: generatedText.ToString());
+    }
+
+    private static void AssertGeneratedSourceCompilesWithoutErrors(string originalSource, string generatedSource)
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(text: originalSource, cancellationToken: cancellationToken),
+                CSharpSyntaxTree.ParseText(text: generatedSource, cancellationToken: cancellationToken),
+            ],
+            references: GetReferences(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        List<Diagnostic> errors = [];
+
+        foreach (Diagnostic diagnostic in compilation.GetDiagnostics(cancellationToken))
+        {
+            if (diagnostic.Severity == DiagnosticSeverity.Error)
+            {
+                errors.Add(diagnostic);
+            }
+        }
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void DuplicateNamespacesProduceOnlyOneGeneratedFile()
     {
         const string SOURCE_1 = """

--- a/src/Credfeto.Version.Information.Generator/Builders/SourceAttributeExtensions.cs
+++ b/src/Credfeto.Version.Information.Generator/Builders/SourceAttributeExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Credfeto.Version.Information.Generator.Builders;
 
@@ -18,6 +19,6 @@ internal static class SourceAttributeExtensions
 
     public static CodeBuilder AppendPublicConstant(this CodeBuilder source, string key, string value)
     {
-        return source.AppendLine($"public const string {key} = \"{value}\";");
+        return source.AppendLine($"public const string {key} = {SymbolDisplay.FormatLiteral(value, quote: true)};");
     }
 }

--- a/src/Credfeto.Version.Information.Generator/Extensions/NamespaceGenerationExtensions.cs
+++ b/src/Credfeto.Version.Information.Generator/Extensions/NamespaceGenerationExtensions.cs
@@ -97,10 +97,18 @@ internal static class NamespaceGenerationExtensions
     {
         foreach (string key in attributes.Keys)
         {
-            string value = attributes[key];
+            string value = SanitiseCommentValue(attributes[key]);
 
             source.AppendLine($"// {key} = {value}");
         }
+    }
+
+    private static string SanitiseCommentValue(string value)
+    {
+        return value
+            .Replace(oldValue: "\r\n", newValue: "\\r\\n")
+            .Replace(oldValue: "\r", newValue: "\\r")
+            .Replace(oldValue: "\n", newValue: "\\n");
     }
 
     private static string RemoveGitHashFromVersion(string source)


### PR DESCRIPTION
## Summary

`AppendPublicConstant` interpolated raw assembly attribute values (`AssemblyCompany`, `AssemblyCopyright`, `AssemblyInformationalVersion`) directly into a C# string literal with no escaping. A value containing a double quote, backslash, or newline produced malformed, uncompilable generated code.

- `SourceAttributeExtensions.AppendPublicConstant` now uses `Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(value, quote: true)` to correctly escape and quote the value.
- The DEBUG-only `DumpAttributes` comment emitter in `NamespaceGenerationExtensions.cs` now sanitises embedded `\r`/`\n` sequences so a newline in an attribute value can't split a `//` comment and corrupt the following generated code.
- Added regression tests covering attribute values containing a double quote, a backslash, and an embedded newline, asserting both the escaped literal is present and the generated source compiles without diagnostics.

Closes #113

## Test plan
- [x] `dotnet build src/Credfeto.Version.Information.slnx -c Release`
- [x] `dotnet test src/Credfeto.Version.Information.Generator.Tests/Credfeto.Version.Information.Generator.Tests.csproj -c Release` — 78/78 passed
- [x] `dotnet test src/Credfeto.Version.Information.Example.Tests/Credfeto.Version.Information.Example.Tests.csproj -c Release` — 8/8 passed
- [x] `dotnet buildcheck -solution src/Credfeto.Version.Information.slnx` — no errors