### PR TITLE
fix: avoid per-line indent string allocation in CodeBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Reduce incremental generator pipeline work and fix model equality so the generator caches correctly across incremental builds
 - Escape attribute values emitted into generated source to prevent invalid C# when values contain quotes, backslashes, or newlines
 ### Changed
+- Reduced allocations in CodeBuilder by writing indentation directly to the StringBuilder instead of allocating an intermediate padded string
 ### Removed
 ### Deployment Changes
 <!--

--- a/src/Credfeto.Version.Information.Generator/Builders/CodeBuilder.cs
+++ b/src/Credfeto.Version.Information.Generator/Builders/CodeBuilder.cs
@@ -53,7 +53,7 @@ public sealed class CodeBuilder
             return this.AppendBlankLine();
         }
 
-        this._stringBuilder.Append(this.IndentCharacters()).AppendLine(text);
+        this._stringBuilder.Append(' ', 4 * this._indent).AppendLine(text);
 
         return this;
     }
@@ -68,13 +68,6 @@ public sealed class CodeBuilder
         this.AppendLine(text);
 
         return new Indent(this, start: start, end: end);
-    }
-
-    private string IndentCharacters()
-    {
-        int indentCharacters = 4 * this._indent;
-
-        return string.Empty.PadLeft(indentCharacters);
     }
 
     private sealed class Indent : IDisposable


### PR DESCRIPTION
## Summary

Scaffolds work on #115: `CodeBuilder.IndentCharacters()` allocates a fresh padded string on every non-blank line emitted via `AppendLine`. This will be replaced with a direct `StringBuilder.Append(' ', 4 * indent)` call, removing the intermediate allocation.

See the [approved implementation plan](https://github.com/credfeto/credfeto-version-constants-generator/issues/115#issuecomment-4925396269) posted on the issue.

Closes #115