### PR TITLE
fix: regenerate cached namespace transform when assembly attributes change in a separate syntax tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Remove shared mutable HashSet from incremental generator to fix disappearing generated VersionInformation class on incremental builds
 - Reduce incremental generator pipeline work and fix model equality so the generator caches correctly across incremental builds
 - Escape attribute values emitted into generated source to prevent invalid C# when values contain quotes, backslashes, or newlines
+- Assembly attribute edits in a separate syntax tree do not invalidate the cached namespace transform, leaving stale Version/Product/Company/Copyright constants (#112)
 ### Changed
 - Reduced allocations in CodeBuilder by writing indentation directly to the StringBuilder instead of allocating an intermediate padded string
 - Dependencies - Updated Meziantou.Analyzer to 3.0.122

--- a/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
+++ b/src/Credfeto.Version.Information.Generator.Tests/VersionInformationCodeGeneratorTests.cs
@@ -489,6 +489,70 @@ public sealed class VersionInformationCodeGeneratorTests : TestBase
         Assert.Equal(1, sources2);
     }
 
+    [Fact]
+    public void RegeneratesSourceWhenAssemblyAttributeChangesInSeparateSyntaxTree()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        const string NAMESPACE_SOURCE = """
+            namespace TestAssembly;
+            public class TestClass { }
+            """;
+
+        const string ATTRIBUTE_SOURCE_V1 = """
+            using System.Reflection;
+            [assembly: AssemblyInformationalVersion("1.0.0")]
+            """;
+
+        const string ATTRIBUTE_SOURCE_V2 = """
+            using System.Reflection;
+            [assembly: AssemblyInformationalVersion("2.0.0")]
+            """;
+
+        SyntaxTree namespaceTree = CSharpSyntaxTree.ParseText(text: NAMESPACE_SOURCE, cancellationToken: cancellationToken);
+        SyntaxTree attributeTreeV1 = CSharpSyntaxTree.ParseText(
+            text: ATTRIBUTE_SOURCE_V1,
+            cancellationToken: cancellationToken
+        );
+
+        CSharpCompilation compilation1 = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [namespaceTree, attributeTreeV1],
+            references: GetReferences(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new VersionInformationCodeGenerator().AsSourceGenerator()],
+            additionalTexts: null,
+            parseOptions: null,
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(null)
+        );
+
+        driver = driver.RunGenerators(compilation: compilation1, cancellationToken: cancellationToken);
+        GeneratorDriverRunResult result1 = driver.GetRunResult();
+
+        Assert.NotEmpty(result1.Results);
+        Assert.NotEmpty(result1.Results[0].GeneratedSources);
+        string generated1 = result1.Results[0].GeneratedSources[0].SourceText.ToString();
+        Assert.Contains("\"1.0.0\"", generated1, StringComparison.Ordinal);
+
+        SyntaxTree attributeTreeV2 = CSharpSyntaxTree.ParseText(
+            text: ATTRIBUTE_SOURCE_V2,
+            cancellationToken: cancellationToken
+        );
+        CSharpCompilation compilation2 = compilation1.ReplaceSyntaxTree(oldTree: attributeTreeV1, newTree: attributeTreeV2);
+
+        driver = driver.RunGenerators(compilation: compilation2, cancellationToken: cancellationToken);
+        GeneratorDriverRunResult result2 = driver.GetRunResult();
+
+        Assert.NotEmpty(result2.Results);
+        Assert.NotEmpty(result2.Results[0].GeneratedSources);
+        string generated2 = result2.Results[0].GeneratedSources[0].SourceText.ToString();
+        Assert.Contains("\"2.0.0\"", generated2, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"1.0.0\"", generated2, StringComparison.Ordinal);
+    }
+
     private static readonly string[] AllTrackingNames =
     [
         VersionInformationCodeGenerator.TRACKING_NAME_HAS_NAMESPACES,


### PR DESCRIPTION
## Summary

- Adds a regression test proving (or disproving) that assembly-attribute edits in a separate syntax tree from the namespace declaration correctly invalidate the cached generator output, per the approved implementation plan on #112.
- Follow-up production-code fix will be added on this branch only if the new test exposes a residual gap after #111's `CompilationProvider`-based pipeline redesign.

## Implementation plan

See the approved plan posted on #112:
https://github.com/credfeto/credfeto-version-constants-generator/issues/112#issuecomment-4924989098

Closes #112

## Test plan

- [ ] Add `RegeneratesSourceWhenAssemblyAttributeChangesInSeparateSyntaxTree` (or similarly named) test to `Credfeto.Version.Information.Generator.Tests`
- [ ] `dotnet buildcheck -solution src/Credfeto.Version.Information.slnx`
- [ ] `dotnet test` across the solution
- [ ] Pre-commit baseline clean