### PR TITLE
Drop net9.0: target net10.0 only (single TargetFramework)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -10,6 +13,8 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 ### Changed
+- Drop net9.0 support: projects now target net10.0 only
+### Deprecated
 ### Removed
 ### Deployment Changes
 <!--

--- a/src/Credfeto.Version.Information.Example.Tests/Credfeto.Version.Information.Example.Tests.csproj
+++ b/src/Credfeto.Version.Information.Example.Tests/Credfeto.Version.Information.Example.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
     <Product>Source Generation</Product>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Version.Information.Generator.Tests/Credfeto.Version.Information.Generator.Tests.csproj
+++ b/src/Credfeto.Version.Information.Generator.Tests/Credfeto.Version.Information.Generator.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
     <Product>Source Generation</Product>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>


### PR DESCRIPTION
## Summary

Scaffolding PR for the approved plan on #128. Per the Implementation Plan (https://github.com/credfeto/credfeto-version-constants-generator/issues/128#issuecomment-4982093472):

- Change every .csproj currently containing <TargetFrameworks>net9.0;net10.0</TargetFrameworks> to a single <TargetFramework>net10.0</TargetFramework>.
- Known affected projects (re-grep at implementation time in case this has drifted):
  - src/Credfeto.Version.Information.Example.Tests/Credfeto.Version.Information.Example.Tests.csproj
  - src/Credfeto.Version.Information.Generator.Tests/Credfeto.Version.Information.Generator.Tests.csproj
- Remove any net9.0-specific dead code (MSBuild Condition blocks, #if NET9_0 non-_OR_GREATER guards) exposed by dropping the target; _OR_GREATER guards remain valid and need no change.
- Check global.json, CI workflow files, and shared Directory.Build.props/.targets for net9.0 pins.

This is a placeholder draft. The TargetFramework change itself follows in a subsequent commit on this branch.

Closes #128

## Test plan

- [ ] Re-grep for <TargetFrameworks>net9.0;net10.0</TargetFrameworks> across the repo in case the affected set has drifted
- [ ] Update all matching .csproj files to <TargetFramework>net10.0</TargetFramework>
- [ ] Remove any now-dead net9.0-specific conditions/guards
- [ ] dotnet buildcheck -solution src/Credfeto.Version.Information.slnx
- [ ] dotnet build
- [ ] dotnet test